### PR TITLE
Fix nil value when security scheme has no scopes

### DIFF
--- a/endpoint/builder.go
+++ b/endpoint/builder.go
@@ -234,6 +234,9 @@ func Tags(tags ...string) Option {
 // Security allows a security scheme to be associated with the endpoint.
 func Security(scheme string, scopes ...string) Option {
 	return func(b *Builder) {
+		if scopes == nil {
+			scopes = []string{}
+		}
 		if b.Endpoint.Security == nil {
 			b.Endpoint.Security = &swagger.SecurityRequirement{}
 		}

--- a/endpoint/builder_test.go
+++ b/endpoint/builder_test.go
@@ -208,6 +208,7 @@ func TestSecurity(t *testing.T) {
 		endpoint.Security("basic"),
 		endpoint.Security("oauth2", "scope1", "scope2"),
 	)
+	assert.Equal(t, e.Security.Requirements[0]["basic"], []string{})
 	assert.False(t, e.Security.DisableSecurity)
 	assert.Len(t, e.Security.Requirements, 2)
 	assert.Contains(t, e.Security.Requirements[0], "basic")


### PR DESCRIPTION
OpenAPI spec says that unscoped security requirements should be an empty array