### PR TITLE
Support security definitions for google endpoints

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -138,15 +138,31 @@ func Endpoints(endpoints ...*swagger.Endpoint) Option {
 
 // SecurityScheme creates a new security definition for the API.
 func SecurityScheme(name string, options ...swagger.SecuritySchemeOption) Option {
+	scheme := swagger.SecurityScheme{}
+
+	for _, opt := range options {
+		opt(&scheme)
+	}
+
+	return SecurityDefinition(name, scheme)
+}
+
+// GoogleSecurityScheme creates a new security definition for the API.
+func GoogleSecurityScheme(name string, options ...swagger.GoogleSecuritySchemeOption) Option {
+	scheme := swagger.GoogleSecurityScheme{}
+
+	for _, opt := range options {
+		opt(&scheme)
+	}
+
+	return SecurityDefinition(name, scheme)
+}
+
+// SecurityDefinition creates a new security definition from a given security scheme for the API.
+func SecurityDefinition(name string, scheme interface{}) Option {
 	return func(builder *Builder) {
 		if builder.API.SecurityDefinitions == nil {
-			builder.API.SecurityDefinitions = map[string]swagger.SecurityScheme{}
-		}
-
-		scheme := swagger.SecurityScheme{}
-
-		for _, opt := range options {
-			opt(&scheme)
+			builder.API.SecurityDefinitions = make(map[string]interface{})
 		}
 
 		builder.API.SecurityDefinitions[name] = scheme

--- a/builder_test.go
+++ b/builder_test.go
@@ -113,7 +113,34 @@ func TestSecurityScheme(t *testing.T) {
 	assert.Len(t, api.SecurityDefinitions, 2)
 	assert.Contains(t, api.SecurityDefinitions, "basic")
 	assert.Contains(t, api.SecurityDefinitions, "apikey")
-	assert.Equal(t, "header", api.SecurityDefinitions["apikey"].In)
+	assert.Equal(t, "header", api.SecurityDefinitions["apikey"].(swagger.SecurityScheme).In)
+}
+
+func TestGoogleSecurityScheme(t *testing.T) {
+	api := swag.New(
+		swag.GoogleSecurityScheme("google-oauth", swagger.GoogleEndpointsSecurity("issuer", "jwks", "aud")),
+	)
+	assert.Len(t, api.SecurityDefinitions, 1)
+	assert.Contains(t, api.SecurityDefinitions, "google-oauth")
+	_, ok := api.SecurityDefinitions["google-oauth"].(swagger.GoogleSecurityScheme)
+	assert.True(t, ok)
+}
+
+type customSecurityScheme struct {
+	swagger.SecurityScheme
+	Foo string `json:"x-custom-foo"`
+	Bar string `json:"x-custom-bar"`
+}
+
+func TestCustomSecurityScheme(t *testing.T) {
+	custom := customSecurityScheme{Foo: "foo", Bar: "bar"}
+	api := swag.New(
+		swag.SecurityDefinition("google-oauth", custom),
+	)
+	assert.Len(t, api.SecurityDefinitions, 1)
+	assert.Contains(t, api.SecurityDefinitions, "google-oauth")
+	_, ok := api.SecurityDefinitions["google-oauth"].(customSecurityScheme)
+	assert.True(t, ok)
 }
 
 func TestSecurity(t *testing.T) {

--- a/endpoint/builder_test.go
+++ b/endpoint/builder_test.go
@@ -199,7 +199,7 @@ func TestSecurityScheme(t *testing.T) {
 	assert.Len(t, api.SecurityDefinitions, 2)
 	assert.Contains(t, api.SecurityDefinitions, "basic")
 	assert.Contains(t, api.SecurityDefinitions, "apikey")
-	assert.Equal(t, "header", api.SecurityDefinitions["apikey"].In)
+	assert.Equal(t, "header", api.SecurityDefinitions["apikey"].(swagger.SecurityScheme).In)
 }
 
 func TestSecurity(t *testing.T) {

--- a/swagger/api.go
+++ b/swagger/api.go
@@ -174,6 +174,7 @@ func GoogleEndpointsSecurity(issuer, jwksURI, audiences string) GoogleSecuritySc
 	return func(securityScheme *GoogleSecurityScheme) {
 		securityScheme.Type = "oauth2"
 		securityScheme.Flow = "implicit"
+		securityScheme.AuthorizationURL = "https://accounts.google.com/o/oauth2/v2/auth"
 		if securityScheme.Scopes == nil {
 			securityScheme.Scopes = map[string]string{}
 		}

--- a/swagger/api_test.go
+++ b/swagger/api_test.go
@@ -138,3 +138,43 @@ func TestOAuth2Scope(t *testing.T) {
 	assert.Equal(t, "read data", scheme.Scopes["read"])
 	assert.Equal(t, "write data", scheme.Scopes["write"])
 }
+
+func TestGoogleOAuth2Security(t *testing.T) {
+	issuer := "https://accounts.google.com"
+	jwksURI := "https://www.googleapis.com/oauth2/v1/certs"
+	audiences := "848149964201.apps.googleusercontent.com,841077041629.apps.googleusercontent.com"
+
+	scheme := &swagger.GoogleSecurityScheme{}
+
+	flow := "accessCode"
+	authURL := "http://example.com/oauth/authorize"
+	tokenURL := "http://example.com/oauth/token"
+	swagger.GoogleOAuth2Security(flow, authURL, tokenURL, issuer, jwksURI, audiences)(scheme)
+
+	assert.Equal(t, scheme.Type, "oauth2")
+	assert.Equal(t, scheme.Flow, "accessCode")
+	assert.Equal(t, scheme.AuthorizationURL, authURL)
+	assert.Equal(t, scheme.TokenURL, tokenURL)
+
+	assert.Equal(t, scheme.Issuer, issuer)
+	assert.Equal(t, scheme.JwksURI, jwksURI)
+	assert.Equal(t, scheme.Audiences, audiences)
+}
+
+func TestGoogleOAuth2(t *testing.T) {
+	issuer := "https://accounts.google.com"
+	jwksURI := "https://www.googleapis.com/oauth2/v1/certs"
+	audiences := "848149964201.apps.googleusercontent.com,841077041629.apps.googleusercontent.com"
+
+	scheme := &swagger.GoogleSecurityScheme{}
+	swagger.GoogleEndpointsSecurity(issuer, jwksURI, audiences)(scheme)
+
+	assert.Equal(t, scheme.Type, "oauth2")
+	assert.Equal(t, scheme.Flow, "implicit")
+	assert.Equal(t, scheme.AuthorizationURL, "")
+	assert.Equal(t, scheme.TokenURL, "")
+
+	assert.Equal(t, scheme.Issuer, issuer)
+	assert.Equal(t, scheme.JwksURI, jwksURI)
+	assert.Equal(t, scheme.Audiences, audiences)
+}


### PR DESCRIPTION
There doesn't seem to be a really good way to support OpenAPI extensions, however this is one approach to support security definition extensions for google endpoints. 

Downside to this is it may break users if for some reason they refer to `api.SecurityDefinitions` which I'm not sure is a huge concern. 

This does however support the ability for users to add further security definition extensions via `swag.SecurityDefinition` if they choose without needing to make a pull request.

Another way would be to just extend the SecurityScheme struct with google extensions, but that means every extension involves a change/PR to this repo. I'm open to ideas here.