### PR TITLE
Add example tag to change response example value

### DIFF
--- a/swagger/reflect.go
+++ b/swagger/reflect.go
@@ -30,6 +30,7 @@ func inspect(t reflect.Type, tag reflect.StructTag) Property {
 
 	jsonTag := tag.Get("json")
 	defaultTag := tag.Get("default")
+	exampleTag := tag.Get("example")
 	formatTag := tag.Get("format")
 	minItemsTag := tag.Get("min_items")
 	maxItemsTag := tag.Get("max_items")
@@ -57,6 +58,10 @@ func inspect(t reflect.Type, tag reflect.StructTag) Property {
 	if strings.Contains(jsonTag, ",string") {
 		p.Type = "string"
 		return p
+	}
+
+	if exampleTag != "" {
+		p.Example = exampleTag
 	}
 
 	var err error


### PR DESCRIPTION
I want to use example field of a swagger file as following:
```
"definitions": {
    "XXX": {
      "type": "object",
      "properties": {
        "sample_data": {
          "type": "string",
          "example": "set value which wants to show value at a response example of swagger UI."
        }
      },
      "additionalProperties": false
    }
  }
```
To use it, I want to add an "example" tag in data struct.
Could you accept my updating?