### PR TITLE
do not generate docs for private fields/params (where name starts wit…

### DIFF
--- a/endpoint/builder.go
+++ b/endpoint/builder.go
@@ -157,6 +157,9 @@ func RequestHeader(name, typ, format, description string, required bool) Option 
 // Query defines a query parameter for the endpoint; name, typ, format, description, and required correspond to the matching
 // swagger fields
 func Query(name, typ, format, description string, required bool) Option {
+	if name[0] == '_' {
+		return func(b *Builder) {}
+	}
 	p := swagger.Parameter{
 		Name:        name,
 		In:          "query",
@@ -179,6 +182,9 @@ func QueryList(params []swagger.Parameter) Option {
 			if param.Name == "" {
 				panic(fmt.Errorf(`QueryList parameter %d: %#v has an empty name`, i, param))
 			}
+			if param.Name[0] == '_' {
+				continue
+			}
 			param.In = "query"
 			b.Endpoint.Parameters = append(b.Endpoint.Parameters, param)
 		}
@@ -193,6 +199,9 @@ func QueryMap(params map[string]swagger.Parameter) Option {
 		}
 
 		for k, v := range params {
+			if k[0] == '_' {
+				continue
+			}
 			v.Name = k
 			v.In = "query"
 			b.Endpoint.Parameters = append(b.Endpoint.Parameters, v)

--- a/endpoint/builder_test.go
+++ b/endpoint/builder_test.go
@@ -125,6 +125,23 @@ func TestQuery(t *testing.T) {
 	assert.Equal(t, expected, e.Parameters[0])
 }
 
+func TestQueryPrivate(t *testing.T) {
+	expected := swagger.Parameter{
+		In:          "query",
+		Name:        "_id",
+		Description: "the description",
+		Required:    true,
+		Type:        "string",
+		Format:      "",
+	}
+
+	e := endpoint.New("get", "/", "get thing",
+		endpoint.Query(expected.Name, expected.Type, expected.Format, expected.Description, expected.Required),
+	)
+
+	assert.Equal(t, 0, len(e.Parameters))
+}
+
 func TestQueryList(t *testing.T) {
 	expected := []swagger.Parameter{{
 		Name:        "id",
@@ -132,21 +149,26 @@ func TestQueryList(t *testing.T) {
 		Required:    true,
 		Type:        "string",
 		Format:      "",
+		In:          "query",
 	}, {
 		Name:        "other",
 		Description: "the description",
 		Required:    true,
 		Type:        "string",
 		Format:      "",
+		In:          "query",
+	}, {
+		Name:        "_private",
+		Description: "the description",
+		Required:    true,
+		Type:        "string",
+		Format:      "",
+		In:          "query",
 	}}
 
 	e := endpoint.New("get", "/", "get thing",
 		endpoint.QueryList(expected),
 	)
-
-	for i := range expected {
-		expected[i].In = "query"
-	}
 
 	assert.Equal(t, 2, len(e.Parameters))
 	assert.Equal(t, expected[0], e.Parameters[0])
@@ -162,7 +184,43 @@ func TestQueryList(t *testing.T) {
 			)
 		},
 	)
+}
 
+func TestQueryMap(t *testing.T) {
+	expected := map[string]swagger.Parameter{
+		"id": {
+			Name:        "id",
+			Description: "the description",
+			Required:    true,
+			Type:        "string",
+			Format:      "",
+			In:          "query",
+		},
+		"other": {
+			Name:        "other",
+			Description: "the description",
+			Required:    true,
+			Type:        "string",
+			Format:      "",
+			In:          "query",
+		},
+		"_private": {
+			Name:        "_private",
+			Description: "the description",
+			Required:    true,
+			Type:        "string",
+			Format:      "",
+			In:          "query",
+		},
+	}
+
+	e := endpoint.New("get", "/", "get thing",
+		endpoint.QueryMap(expected),
+	)
+
+	assert.Equal(t, 2, len(e.Parameters))
+	assert.Equal(t, expected["id"], e.Parameters[0])
+	assert.Equal(t, expected["other"], e.Parameters[1])
 }
 
 type Model struct {

--- a/swagger/reflect.go
+++ b/swagger/reflect.go
@@ -539,6 +539,10 @@ func defineObject(v interface{}) Object {
 				// honor json ignore tag
 				continue
 			}
+			if name[0] == '_' {
+				// skip 'private' fields
+				continue
+			}
 
 			// determine if this field is required or not
 			if v := field.Tag.Get("required"); v == "true" {

--- a/swagger/reflect_test.go
+++ b/swagger/reflect_test.go
@@ -154,6 +154,19 @@ func TestIgnoreUnexported(t *testing.T) {
 	assert.NotContains(t, obj.Properties, "unexported")
 }
 
+func TestIgnorePrivate(t *testing.T) {
+	type Test struct {
+		Exported string
+		Private  string `json:"_private"`
+	}
+	v := define(Test{})
+	obj, ok := v["swaggerTest"]
+	assert.True(t, ok)
+	assert.Equal(t, 1, len(obj.Properties), "expected one exposed properties")
+	assert.Contains(t, obj.Properties, "Exported")
+	assert.NotContains(t, obj.Properties, "Private")
+}
+
 func TestCustomTypes(t *testing.T) {
 	type ContainsCustomType struct {
 		TestTime time.Time `json:"testTime"`


### PR DESCRIPTION
…h '_')