### PR TITLE
Updated SWAG reflect to handle map[string]*string types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,15 +3,13 @@ module github.com/miketonks/swag
 go 1.16
 
 require (
-	github.com/gin-gonic/gin v1.7.4 // indirect
-	github.com/gorilla/mux v1.8.0 // indirect
-	github.com/julienschmidt/httprouter v1.3.0 // indirect
-	github.com/labstack/echo v3.3.10+incompatible // indirect
+	github.com/gin-gonic/gin v1.7.4
+	github.com/gorilla/mux v1.8.0
+	github.com/julienschmidt/httprouter v1.3.0
+	github.com/labstack/echo v3.3.10+incompatible
 	github.com/labstack/gommon v0.3.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
-	github.com/stretchr/testify v1.7.0 // indirect
+	github.com/stretchr/testify v1.7.0
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
-	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
-	gopkg.in/go-playground/validator.v8 v8.18.2 // indirect
 )

--- a/swagger/reflect.go
+++ b/swagger/reflect.go
@@ -485,6 +485,8 @@ func defineObject(v interface{}) Object {
 		t = reflect.TypeOf(v)
 	}
 
+	objectName := makeName(t)
+
 	properties := map[string]Property{}
 	isArray := t.Kind() == reflect.Slice
 
@@ -497,14 +499,14 @@ func defineObject(v interface{}) Object {
 
 	if t.Kind() != reflect.Struct {
 		p := inspect(t, "")
-		nameTokens := strings.Split(p.GoType.String(), ".")
 		return Object{
-			IsArray:  isArray,
-			GoType:   t,
-			Type:     p.Type,
-			Format:   p.Format,
-			Name:     nameTokens[len(nameTokens)-1],
-			Required: required,
+			IsArray:              isArray,
+			GoType:               t,
+			Type:                 p.Type,
+			Format:               p.Format,
+			Name:                 objectName,
+			Required:             required,
+			AdditionalProperties: t.Kind() == reflect.Map,
 		}
 	}
 
@@ -572,7 +574,7 @@ func defineObject(v interface{}) Object {
 		IsArray:    isArray,
 		GoType:     t,
 		Type:       "object",
-		Name:       makeName(t),
+		Name:       objectName,
 		Required:   required,
 		Properties: properties,
 	}

--- a/swagger/reflect_test.go
+++ b/swagger/reflect_test.go
@@ -124,13 +124,23 @@ func TestNotStructDefine(t *testing.T) {
 	assert.Equal(t, "int32", obj.Format)
 
 	v = define([]byte{1, 2})
-	obj, ok = v["uint8"]
+	obj, ok = v["arr_uint8"]
 	if !assert.True(t, ok) {
 		fmt.Printf("%v", v)
 	}
 	assert.True(t, obj.IsArray)
 	assert.Equal(t, "integer", obj.Type)
 	assert.Equal(t, "int32", obj.Format)
+
+	v = define(map[string]string{"foo": "bar"})
+	obj, ok = v["map_string_to_string"]
+	if !assert.True(t, ok) {
+		fmt.Printf("%v", v)
+	}
+	assert.False(t, obj.IsArray)
+	assert.Equal(t, "object", obj.Type)
+	assert.Equal(t, "", obj.Format)
+	assert.True(t, obj.AdditionalProperties)
 }
 
 func TestHonorJsonIgnore(t *testing.T) {

--- a/swagger/util.go
+++ b/swagger/util.go
@@ -31,14 +31,20 @@ func makeRef(name string) string {
 type reflectType interface {
 	PkgPath() string
 	Name() string
+	String() string
 }
 
 func makeName(t reflectType) string {
-	var name string
-	if UsePackageName {
-		name = filepath.Base(t.PkgPath()) + t.Name()
+	name := t.Name()
+	if name != "" && t.PkgPath() != "" && UsePackageName {
+		name = filepath.Base(t.PkgPath()) + name
+	} else if name != "" {
 	} else {
-		name = filepath.Base(t.Name())
+		name = t.String()
+		name = strings.ReplaceAll(name, "[]", "arr_")
+		name = strings.ReplaceAll(name, "*", "ptr_")
+		name = strings.ReplaceAll(name, "[", "_")
+		name = strings.ReplaceAll(name, "]", "_to_")
 	}
 	return strings.Replace(name, "-", "_", -1)
 }

--- a/swagger/util.go
+++ b/swagger/util.go
@@ -38,8 +38,7 @@ func makeName(t reflectType) string {
 	name := t.Name()
 	if name != "" && t.PkgPath() != "" && UsePackageName {
 		name = filepath.Base(t.PkgPath()) + name
-	} else if name != "" {
-	} else {
+	} else if name == "" {
 		name = t.String()
 		name = strings.ReplaceAll(name, "[]", "arr_")
 		name = strings.ReplaceAll(name, "*", "ptr_")

--- a/swagger/util_test.go
+++ b/swagger/util_test.go
@@ -23,6 +23,7 @@ import (
 type Mock struct {
 	name string
 	pkg  string
+	str  string
 }
 
 func (m Mock) PkgPath() string {
@@ -33,10 +34,33 @@ func (m Mock) Name() string {
 	return m.name
 }
 
+func (m Mock) String() string {
+	return m.str
+}
+
 func TestMakeSchema(t *testing.T) {
+	UsePackageName = true
 	name := makeName(Mock{
 		name: "Name",
 		pkg:  "with-some-dashes",
 	})
 	assert.Equal(t, "with_some_dashesName", name)
+
+	name = makeName(Mock{
+		str: "string",
+	})
+	assert.Equal(t, "string", name)
+
+	UsePackageName = false
+
+	name = makeName(Mock{
+		name: "Name",
+		pkg:  "with-some-dashes",
+	})
+	assert.Equal(t, "Name", name)
+
+	name = makeName(Mock{
+		str: "string",
+	})
+	assert.Equal(t, "string", name)
 }


### PR DESCRIPTION
Example use case:

```
swagger.RegisterCustomType(map[string]*string{}, swagger.Property{
    Type: "object",
    AdditionalProperties: &swagger.Property{
        Type:     "string",
        Nullable: true,
        GoType:   reflect.ValueOf((*string)(nil)).Type(),
    },
})
```
